### PR TITLE
Update provider_test.php

### DIFF
--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -21,7 +21,7 @@
  * @copyright  Microsoft, Inc.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-namespace assignfeedback_onenote\privacy;
+namespace assignsubmission_onenote\privacy;
 
 defined('MOODLE_INTERNAL') || die();
 


### PR DESCRIPTION
Fails Unit Tests - PHP Fatal error:  Cannot declare class assignfeedback_onenote\privacy\provider_test, because the name is already in use