### PR TITLE
Fix unit test failing from MDL-81520

### DIFF
--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -43,7 +43,7 @@ require_once($CFG->dirroot . '/mod/assign/tests/privacy/provider_test.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers \assignsubmission_onenote\privacy\provider
  */
-final class provider_test extends \mod_assign\privacy\provider_test {
+final class provider_test extends \mod_assign\tests\provider_testcase {
     /**
      * Quick test to make sure that get_metadata returns something.
      *


### PR DESCRIPTION
This is the same issue as https://github.com/microsoft/o365-moodle/issues/2735

Caused from https://tracker.moodle.org/browse/MDL-81520

MDL-81520 is already in the Moodle core: https://github.com/moodle/moodle/commits/MOODLE_405_STABLE/